### PR TITLE
Add Supabase logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 import re
 import streamlit as st
-import os, json, datetime
+import datetime
+
+from log import SupabaseLogger
 
 from rewriter.api import ArticleRewriter
 
@@ -23,6 +25,7 @@ if not st.session_state["password_correct"]:
 
 
 rewriter = ArticleRewriter()
+logger = SupabaseLogger()
 
 # Buffer state
 if "article_buffer" not in st.session_state:
@@ -162,17 +165,15 @@ with col2:
                         openai, openai_key, gpt_4o, writing_prompt, translated_text
                     )
 
-                    # logging 
-                    os.makedirs("logs", exist_ok=True)
-                    timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+                    timestamp = datetime.datetime.utcnow().isoformat()
                     log_data = {
                         "user_prompt": user_prompt,
-                        "translated_text": translated_text, 
+                        "translated_text": translated_text,
                         "writing_prompt": writing_prompt,
-                        "generated_article": generated_article
+                        "generated_article": generated_article,
+                        "timestamp": timestamp,
                     }
-                    with open(f"logs/{timestamp}.json", "w") as f:
-                        json.dump(log_data, f, ensure_ascii=False, indent=2)
+                    logger.log(log_data)
     
                     st.text_area(
                         "Generated Article:",

--- a/log.py
+++ b/log.py
@@ -1,0 +1,16 @@
+from typing import Dict
+import streamlit as st
+from supabase import create_client, Client
+
+
+class SupabaseLogger:
+    """Simple logger that writes entries to a Supabase table."""
+
+    def __init__(self):
+        url: str = st.secrets["SUPABASE_URL"]
+        key: str = st.secrets["SUPABASE_SERVICE_KEY"]
+        self.client: Client = create_client(url, key)
+
+    def log(self, data: Dict):
+        """Insert a log record into the 'logs' table."""
+        self.client.table("logs").insert(data).execute()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 requests
+supabase-py


### PR DESCRIPTION
## Summary
- remove local file logging from app
- add `log.py` to send logs to Supabase
- initialize `SupabaseLogger` in the app
- require `supabase-py` dependency

## Testing
- `python -m py_compile app.py log.py rewriter/api.py`

------
https://chatgpt.com/codex/tasks/task_e_684457676640832b8e4792cde7cb4e70